### PR TITLE
Fix indentation on SessionEndedRequestHandler/handle

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -224,7 +224,7 @@ class SessionEndedRequestHandler(AbstractRequestHandler):
     def handle(self, handler_input):
         # type: (HandlerInput) -> Response
 
-         global home_assistant_object
+        global home_assistant_object
         if home_assistant_object == None:
             home_assistant_object = HomeAssistant(handler_input)
             home_assistant_object.get_ha_state()


### PR DESCRIPTION
The indentation on line 227, with the `global` statement, is wrong and breaks the skill.