### PR TITLE
strip trailing '/' from home assistant urls

### DIFF
--- a/lambda/lambda_function.py
+++ b/lambda/lambda_function.py
@@ -27,6 +27,7 @@ from ask_sdk_model import Response
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
+HOME_ASSISTANT_URL = HOME_ASSISTANT_URL.rstrip('/')
 
 INPUT_TEXT_ENTITY = "input_text.alexa_actionable_notification"
 


### PR DESCRIPTION
removes a common initial error as most places you get the url (like from nabu casa) it has the trailing slash.  Personally this tripped me up for a while