### PR TITLE
update interactionModels for string intents

### DIFF
--- a/skill-package/interactionModels/custom/de-DE.json
+++ b/skill-package/interactionModels/custom/de-DE.json
@@ -36,11 +36,11 @@
           "slots": [
             {
               "name": "Strings",
-              "type": "AMAZON.SearchQuery"
+              "type": "AMAZON.Person"
             }
           ],
           "samples": [
-            " {Strings}"
+            "{Strings}"
           ]
         },
         {

--- a/skill-package/interactionModels/custom/en-US.json
+++ b/skill-package/interactionModels/custom/en-US.json
@@ -36,11 +36,11 @@
           "slots": [
             {
               "name": "Strings",
-              "type": "AMAZON.SearchQuery"
+              "type": "AMAZON.Person"
             }
           ],
           "samples": [
-            " {Strings}"
+            "{Strings}"
           ]
         },
         {

--- a/skill-package/interactionModels/custom/es-ES.json
+++ b/skill-package/interactionModels/custom/es-ES.json
@@ -32,10 +32,10 @@
           "slots": [
             {
               "name": "Strings",
-              "type": "AMAZON.SearchQuery"
+              "type": "AMAZON.Person"
             }
           ],
-          "samples": [" {Strings}"]
+          "samples": ["{Strings}"]
         },
         {
           "name": "Select",

--- a/skill-package/interactionModels/custom/fr-FR.json
+++ b/skill-package/interactionModels/custom/fr-FR.json
@@ -37,11 +37,11 @@
           "slots": [
             {
               "name": "Strings",
-              "type": "AMAZON.SearchQuery"
+              "type": "AMAZON.Person"
             }
           ],
           "samples": [
-            " {Strings}"
+            "{Strings}"
           ]
         },
         {

--- a/skill-package/interactionModels/custom/it-IT.json
+++ b/skill-package/interactionModels/custom/it-IT.json
@@ -36,11 +36,11 @@
           "slots": [
             {
               "name": "Strings",
-              "type": "AMAZON.SearchQuery"
+              "type": "AMAZON.Person"
             }
           ],
           "samples": [
-            " {Strings}"
+            "{Strings}"
           ]
         },
         {

--- a/skill-package/interactionModels/custom/pt-BR.json
+++ b/skill-package/interactionModels/custom/pt-BR.json
@@ -40,11 +40,11 @@
           "slots": [
             {
               "name": "Strings",
-              "type": "AMAZON.SearchQuery"
+              "type": "AMAZON.Person"
             }
           ],
           "samples": [
-            " {Strings}"
+            "{Strings}"
           ]
         },
         {


### PR DESCRIPTION
This addresses the issues https://github.com/keatontaylor/alexa-actions/issues/177 and https://github.com/keatontaylor/alexa-actions/issues/178

The slot-type **AMAZON.SearchQuery** can no longer use a space as the carrier phrase. When attempting to import or update an interaction model, the following error message is thrown:
`Sample utterance " {Strings}" in intent "String" must include a carrier phrase. Sample intent utterances with phrase types cannot consist of only slots.`


The cause of this error is the following code:
`{ "name": "String", "slots": [ { "name": "Strings", "type": "AMAZON.SearchQuery" } ], "samples": [ " {Strings}" ] }.`

A comment from @marloncarvalho https://github.com/keatontaylor/alexa-actions/issues/177#issuecomment-1529620323 suggests adding a word before {Strings} resulting to:
`{ "name": "String", "slots": [ { "name": "Strings", "type": "AMAZON.SearchQuery" } ], "samples": [ "hi {Strings}" ] }`

However, this workaround has the downside of only recognizing a ResponseString with the added word.


To address this issue, the slot-type **AMAZON.Person** can be used instead. For now, this slot-type does not require a carrier phrase in the samples, which fixes the problems described.