### PR TITLE
Change change AMAZON.FOUR_DIGIT_NUMBER to AMAZON.NUMBER in interaction-models for all languages.

### DIFF
--- a/skill-package/interactionModels/custom/de-DE.json
+++ b/skill-package/interactionModels/custom/de-DE.json
@@ -60,7 +60,7 @@
           "slots": [
             {
               "name": "Numbers",
-              "type": "AMAZON.FOUR_DIGIT_NUMBER"
+              "type": "AMAZON.NUMBER"
             }
           ],
           "samples": [

--- a/skill-package/interactionModels/custom/en-US.json
+++ b/skill-package/interactionModels/custom/en-US.json
@@ -60,7 +60,7 @@
           "slots": [
             {
               "name": "Numbers",
-              "type": "AMAZON.FOUR_DIGIT_NUMBER"
+              "type": "AMAZON.NUMBER"
             }
           ],
           "samples": [

--- a/skill-package/interactionModels/custom/es-ES.json
+++ b/skill-package/interactionModels/custom/es-ES.json
@@ -52,7 +52,7 @@
           "slots": [
             {
               "name": "Numbers",
-              "type": "AMAZON.FOUR_DIGIT_NUMBER"
+              "type": "AMAZON.NUMBER"
             }
           ],
           "samples": ["{Numbers}"]

--- a/skill-package/interactionModels/custom/fr-FR.json
+++ b/skill-package/interactionModels/custom/fr-FR.json
@@ -61,7 +61,7 @@
           "slots": [
             {
               "name": "Numbers",
-              "type": "AMAZON.FOUR_DIGIT_NUMBER"
+              "type": "AMAZON.NUMBER"
             }
           ],
           "samples": [

--- a/skill-package/interactionModels/custom/it-IT.json
+++ b/skill-package/interactionModels/custom/it-IT.json
@@ -60,7 +60,7 @@
           "slots": [
             {
               "name": "Numbers",
-              "type": "AMAZON.FOUR_DIGIT_NUMBER"
+              "type": "AMAZON.NUMBER"
             }
           ],
           "samples": [

--- a/skill-package/interactionModels/custom/pt-BR.json
+++ b/skill-package/interactionModels/custom/pt-BR.json
@@ -64,7 +64,7 @@
           "slots": [
             {
               "name": "Numbers",
-              "type": "AMAZON.FOUR_DIGIT_NUMBER"
+              "type": "AMAZON.NUMBER"
             }
           ],
           "samples": [


### PR DESCRIPTION
The Alexa Service only reacted to FOUR DIGIT NUMBERS for the NumberIntentHelper.
It did not recognize any one-digit, two-digit ... or 10 digit number as "NumberIntentHandler.
Changing the interaction model made it possible to answer to Alexa requests through this skill with a number like "5" or "25436".